### PR TITLE
Avoid a warning about uninitialized values

### DIFF
--- a/modules/Bio/EnsEMBL/Test/DumpDatabase.pm
+++ b/modules/Bio/EnsEMBL/Test/DumpDatabase.pm
@@ -219,7 +219,7 @@ sub _schema_differences {
   return 1 unless $old_schema_details && $new_schema_details;
   
   my $old_schema_concat = join(qq{\n}, map { $old_schema_details->{$_}->{create} } sort keys %$old_schema_details);
-  my $new_schema_concat = join(qq{\n}, map { $new_schema_details->{$_}->{create} } sort keys %$old_schema_details);
+  my $new_schema_concat = join(qq{\n}, map { $new_schema_details->{$_}->{create} || '' } sort keys %$old_schema_details);
   
   return ( $old_schema_concat ne $new_schema_concat ) ? 1 : 0;
 }


### PR DESCRIPTION
The warning is "Use of uninitialized value in join or string at
.../ensembl-test/modules/Bio/EnsEMBL/Test/DumpDatabase.pm line 222."
and happens when a table has been remove (by the patch) between the
previous and the current schema versions
