### PR TITLE
Refuse to create a database if its name is too long

### DIFF
--- a/modules/Bio/EnsEMBL/Test/MultiTestDB.pm
+++ b/modules/Bio/EnsEMBL/Test/MultiTestDB.pm
@@ -380,6 +380,12 @@ sub load_database {
 
     $config_hash->{dbname} = $dbname;
     $self->note("Creating database $dbname");
+    my %limits = ( 'mysql' => 64, 'pg' => 63 );
+    if (my $l = $limits{lc $self->db_conf->{driver}}) {
+        if (length($dbname) > $l) {
+            die "Cannot create the database because its name is longer than the maximum the driver allows ($l characters)";
+        }
+    }
     my $db = $self->create_and_use_db($driver_handle, $dbname);
 
     my $base_dir = $self->base_dump_dir($self->curr_dir());


### PR DESCRIPTION
(cc-ing @carlacummins)

In MySQL, database names are 64 characters at most. In case the generated dbname is too long, MySQL refuses to create the database but doesn't report it in a meaningful way
```
ok 1 - use Bio::EnsEMBL::Compara::RunnableDB::OrthologQM::SelectMLSS;
# Reblessed to 'Bio::EnsEMBL::Test::MultiTestDB::mysql'
# Trying to load [orth_qm_test] databases
# Creating database matthieu_test_db_orth_qm_test_cc21_select_mlss_test_20160224_174138
DBD::mysql::db do failed: Incorrect database name 'matthieu_test_db_orth_qm_test_cc21_select_mlss_test_20160224_174138' at /home/matthieu/workspace/src/dev/ensembl-test/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm line 51.
DBD::mysql::db do failed: Incorrect database name 'matthieu_test_db_orth_qm_test_cc21_select_mlss_test_20160224_174138' at /home/matthieu/workspace/src/dev/ensembl-test/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm line 51.
# Cleaning up...
# !! Database adaptor of type cc21_select_mlss_test is not available
        (in cleanup) adaptor for cc21_select_mlss_test is not available at /home/matthieu/workspace/src/dev/ensembl-test/modules/Bio/EnsEMBL/Test/MultiTestDB.pm line 511.
# Tests were run but no plan was declared and done_testing() was not seen.
```

This commits makes MultiTestDB itself refuse to create the database

PS: You can easily reproduce the bug by setting the LOGNAME environment variable to a veeeeery long string when running a test