### PR TITLE
[ENSCORESW-2820] Update links in pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ### Requirements
 
 - Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
-- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
+- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
     - do not modify code without testing for regression
     - provide simple unit tests to test the changes
     - the PR must not fail unit testing


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing

### Description

Update links in the pull request template to point to documents in the master branch

### Use case

Links were pointing to documents in release/90, making it difficult to update supporting documentation referenced in the PR template

### Benefits

Makes our developer documentation easier to maintain. Contributors have access to the most up to date contribution guidelines.

### Possible Drawbacks

None

### Testing

_Have you added/modified unit tests to test the changes?_

Verified that links direct to the correct page

_If so, do the tests pass/fail?_

Pass

_Have you run the entire test suite and no regression was detected?_

Yes