### PR TITLE
[ENSCORESW-2622] DBIx warning in patch test databases

### DIFF
--- a/scripts/dump_test_schema.pl
+++ b/scripts/dump_test_schema.pl
@@ -188,7 +188,7 @@ sub patch_ddl {
 
 sub connected_schema {
     my ($self) = @_;
-    return $self->schema_class->connect( [ sub { $self->dbc->db_handle } ] );
+    return $self->schema_class->connect;
 }
 
 no Moose;

--- a/scripts/dump_test_schema.pl
+++ b/scripts/dump_test_schema.pl
@@ -156,7 +156,11 @@ sub get_MultiTestDB {
 sub make_schema {
     my ($self) = @_;
 
-    my $loader_options = { naming => 'current' };
+    my $loader_options = {
+        naming => 'current',
+        col_collision_map => 'column_%s',
+    };
+
     $loader_options->{dump_directory} = $self->schema_dir if $self->dump_schema;
 
     make_schema_at($self->schema_class, $loader_options, [ sub { $self->dbc->db_handle } ]);


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing

### Description

https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2622

### Use case

Some warnings popping up. 

### Benefits

Warnings go away.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
May break something else unexpected? 

### Testing

I have tested patching the test databases and everything looked good with no warnings.