### PR TITLE
allow new licence format without copyright year

### DIFF
--- a/modules/Bio/EnsEMBL/Test/TestUtils.pm
+++ b/modules/Bio/EnsEMBL/Test/TestUtils.pm
@@ -460,7 +460,7 @@ sub all_has_apache2_licence {
 =cut
 
 sub has_apache2_licence {
-  my ($file) = @_;
+  my ($file, $no_affiliation) = @_;
   my $count = 0;
   my $max_lines = 30;
   my ($found_copyright, $found_url, $found_warranties, $skip_test, $found_sanger_embl_ebi_year, $found_embl_ebi_year) = (0,0,0,0,0,0);
@@ -485,7 +485,10 @@ sub has_apache2_licence {
     return __PACKAGE__->builder->ok(1, "$file has a no critic (RequireApache2Licence) directive");
   }
   if($found_copyright && $found_url && $found_warranties && $found_sanger_embl_ebi_year && $found_embl_ebi_year) {
-    return __PACKAGE__->builder->ok(1, "$file has a Apache v2.0 licence declaration and correct Copyright year [2016-$current_year]");
+    return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration and correct Copyright year [2016-$current_year]");
+  }
+  if ($found_copyright && $found_url && $found_warranties && $no_affiliation) {
+    return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration with no Copyright year");
   }
   __PACKAGE__->builder->diag("$file is missing Apache v2.0 declaration") unless $found_copyright;
   __PACKAGE__->builder->diag("$file is missing Apache URL")              unless $found_url;

--- a/modules/Bio/EnsEMBL/Test/TestUtils.pm
+++ b/modules/Bio/EnsEMBL/Test/TestUtils.pm
@@ -484,11 +484,12 @@ sub has_apache2_licence {
   if($skip_test) {
     return __PACKAGE__->builder->ok(1, "$file has a no critic (RequireApache2Licence) directive");
   }
-  if($found_copyright && $found_url && $found_warranties && $found_sanger_embl_ebi_year && $found_embl_ebi_year) {
-    return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration and correct Copyright year [2016-$current_year]");
-  }
-  if ($found_copyright && $found_url && $found_warranties && $no_affiliation) {
-    return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration with no Copyright year");
+  if($found_copyright && $found_url && $found_warranties) {
+    if ($found_sanger_embl_ebi_year && $found_embl_ebi_year) {
+      return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration and correct Copyright year [2016-$current_year]");
+    } elsif ($no_affiliation) {
+      return __PACKAGE__->builder->ok(1, "$file has an Apache v2.0 licence declaration with no Copyright year");
+    }
   }
   __PACKAGE__->builder->diag("$file is missing Apache v2.0 declaration") unless $found_copyright;
   __PACKAGE__->builder->diag("$file is missing Apache URL")              unless $found_url;


### PR DESCRIPTION
### Requirements

- Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion;
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/release/90/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - the PR must not fail unit testing

### Description

_In one or more sentences, describie in detail the proposed changes._
Allow licences to not have the copyright year in every single file

### Use case

_Describe the problem. Please provide an example representing the motivation behind the need for having these changes in place._
For new repositories, the different licence affiliations are provided in a single NOTICE file at the root of the repository. This has the advantage of having all affiliations in a single place and remove the need to update all files in a repository every time the licence year changes.
The change to the has_apache2_licence allows one to add a 'no_affiliation' flag in the method call, hence skipping the check on EBI/Sanger year licensing.

### Benefits

_If applicable, describe the advantages the changes will have._
The method can be used for both types of repositories, whether the year licensing is in a single root file or across all files in the repository. It also does not affect existing functionality so tests already using this method will not need to be updated.

### Possible Drawbacks

_If applicable, describe any possible undesirable consequence of the changes._
If a flag is accidentally added to the method, we do not check for the year any more even if the repository requires it

### Testing

_Have you added/modified unit tests to test the changes?_
The method was added to some unit tests in a new repository

_If so, do the tests pass/fail?_
Pass

_Have you run the entire test suite and no regression was detected?_
NA

