### PR TITLE
Custom prefix for MultiTestDB database names

### DIFF
--- a/modules/Bio/EnsEMBL/Test/MultiTestDB.pm
+++ b/modules/Bio/EnsEMBL/Test/MultiTestDB.pm
@@ -781,7 +781,11 @@ sub create_db_name {
   # Create a unique name using host and date / time info
   my $db_name = sprintf(
       '%s_test_db_%s_%s_%s_%s',
-      ( exists $ENV{'LOGNAME'} ? $ENV{'LOGNAME'} : $ENV{'USER'} ),
+      (
+        exists $ENV{'ENSEMBL_TESTDB_PREFIX'} ? $ENV{'ENSEMBL_TESTDB_PREFIX'}
+          : exists $ENV{'LOGNAME'}           ? $ENV{'LOGNAME'}
+          : $ENV{'USER'}
+      ),
       $species, $dbtype, $date, $time
   );
   if (my $path = $self->_db_path($self->dbi_connection)) {


### PR DESCRIPTION
### Description

Set the prefix used by MultiTestDB to generate unique database names to the contents of the environment variable ENSEMBL_TESTDB_PREFIX if it exist, reverting to the old behaviour of using local user name if it does not.

### Use case

Until now, MultiTestDB would prefix the names of test databases it creates with the local user name as determined by looking at the environment variables: LOGNAME and USER, in the order as written here. There are the following problems with this approach:
 * it leaks local user names to the database system and by extension to everyone who can access them,
 * in the event of said local user names being different from farm ones it makes it more difficult to identify to whom a specific database belongs.

### Benefits

One now easily prevent the local user name from being leaked, and if the new environment variable is set to the user's login name on the EBI farm it will make it easier for whoever inspects the database server to determine to whom various databases belong.

### Possible Drawbacks

None I can think of.

### Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Have run the test suite for both _ensembl-test_ and, just to see what would happen, _ensembl_. No regression detected.
