### PR TITLE
Make sure Travis installs IO::Scalar before building Net::FTPServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ before_install:
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:
+  # Install IO::Scalar before processing the cpanfile because one of the dependencies
+  # of Test::FTP::Server requires it yet does not declare it as a dependency, and
+  # cpanm - or to be precise the module CPAN::Meta::Prereqs - scrambles the order
+  # of entries in cpanfiles (see https://github.com/miyagawa/cpanfile/issues/42).
+  # Cpanfile upstream categorically refuses to implement the forcing of dependencies
+  # (see https://github.com/miyagawa/cpanfile/issues/3) so we will have to keep this
+  # here until either Net::FTPServer has been fixed or we stop using Test::FTP::Server
+  - cpanm -n IO::Scalar
   - cpanm -v --installdeps --notest .
   - cpanm -n Devel::Cover::Report::Coveralls
   - cpanm -n DBD::SQLite


### PR DESCRIPTION
### Description

One of the dependencies of Test::FTP::Server requires IO::Scalar to be installed yet does not declare it as a dependency. It is not possible to either specify the order in which modules listed in the cpanfile are processed (these are passed to the module CPAN::Meta::Prereqs, which stores them in a hash - meaning their order is essentially random, if influenced by what data gets put in that hash or even on the Perl version used) or explicitly declare one cpanfile entry to be dependent on another (upstream have clearly expressed they have no intention to implement workarounds for other people's broken install scripts), therefore the only way to make sure installing Test::FTP::Server via the cpanfile succeeds is to install IO::Scalar before running _cpanm --installdeps ._.

### Use case

Heisenbugs currently present in our Travis builds: installing Perl modules works under one Perl version yet fails under another, seemingly unrelated changes to the cpanfile such as adding another module there make the problem either disappear or suddently reappear, and so on.

### Benefits

Stops Travis builds from semi-randomly failing due to being unable to install Test::FTP::Server.

### Possible Drawbacks

Only applies to Travis, _i.e._ installing dependencies from the cpanfile might still fail on other platforms. Addressing this systematically would require either fixing the dependency tree of the problematic module (Net::FTPServer) or phasing out Test::FTP::Server.

### Testing

_Have you added/modified unit tests to test the changes?_

No

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected.
