### PR TITLE
Add a README with the Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Ensembl test harness and related utility scripts
+
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-test.svg?branch=master)][travis]
+
+[travis]: https://travis-ci.org/Ensembl/ensembl-test


### PR DESCRIPTION
### Description

Add a README with the Travis badge.

### Use case

We do have a test suite in and Travis configured for this repository.

### Benefits

Quicker access to build status. More repo front-page consistency across Infrastructure.

### Testing

Change does not affect the code itself. The badge does show on the PR branch.