### PR TITLE
Fixed bug when core dbs don't have contigs

### DIFF
--- a/scripts/clone_core_database.pl
+++ b/scripts/clone_core_database.pl
@@ -229,7 +229,7 @@ sub copy_regions {
     my ($name, $start, $end, $coord_system, $version) = @{$region};
     my $strand = undef;
     $coord_system ||= 'toplevel';
-    #Make the assumption that the core API is OK and that the 3 levels of assembly are chromosome, supercontig and contig
+    #Make the assumption that the core API is OK
     #Also only get those slices which are unique
     my $slice = $slice_adaptor->fetch_by_region($coord_system, $name, $start, $end, $strand, $version);
     if(! $slice) {
@@ -237,22 +237,12 @@ sub copy_regions {
       next;
     }
     push(@toplevel_slices, $slice);
-    my $supercontigs;
 
-    #May not always have supercontigs
-    if ( $coord_systems->{'supercontig'} ) {
-      $supercontigs = $slice->project('supercontig');
-      foreach my $supercontig (@$supercontigs) {
-        my $supercontig_slice = $supercontig->[2];
-        $seq_region_id_list{$supercontig_slice->get_seq_region_id} = 1;
-      }
-    }
-
-    #Assume always have contigs
-    my $contigs = $slice->project('contig');
-    foreach my $contig (@$contigs) {
-      my $contig_slice = $contig->[2];
-      $seq_region_id_list{$contig_slice->get_seq_region_id} = 1;
+    #'sequence_level' can be different than 'contig' (e.g. 'primary_assembly')
+    my $fragments = $slice->project('seqlevel');
+    foreach my $frag (@$fragments) {
+      my $frag_slice = $frag->[2];
+      $seq_region_id_list{$frag_slice->get_seq_region_id} = 1;
     }
 
   }

--- a/scripts/clone_core_database.pl
+++ b/scripts/clone_core_database.pl
@@ -237,6 +237,9 @@ sub copy_regions {
 
     #'sequence_level' can be different than 'contig' (e.g. 'primary_assembly')
     my $fragments = $slice->project('seqlevel');
+    if (scalar @$fragments == 0) {
+      die "No assemblies projected from 'seqlevel' to '$coord_system'";
+    }
     foreach my $frag (@$fragments) {
       my $frag_slice = $frag->[2];
       $seq_region_id_list{$frag_slice->get_seq_region_id} = 1;

--- a/scripts/clone_core_database.pl
+++ b/scripts/clone_core_database.pl
@@ -215,9 +215,6 @@ sub copy_globals {
 # Starts the copy across of Slices
 sub copy_regions {
   my ($self, $from, $to, $regions, $is_dna) = @_;
-  my $coord_sql = "select name, coord_system_id from coord_system";
-  my $coord_systems = $to->dbc->sql_helper()->execute_into_hash(-SQL => $coord_sql);
-
   my $slice_adaptor = $from->get_adaptor("Slice");
   my $seq_region_names;
 


### PR DESCRIPTION
### Description
Removed assumption that the 3 levels of assembly are chromosome, supercontig and contig, as there are many other species with different `coord_system` sequence level (e.g. primary assembly, scaffold).

Furthermore, a similar error might be raised in the future regarding supercontigs, and since `toplevel` and `seqlevel` are linked in the assembly table, that part of the code has also been removed.

### Possible Drawbacks
If the intermediate `coord_systems` are required to be cloned, a new piece of code that loops over the ranks between `toplevel` and `seqlevel` should be implemented.

### Testing
The code has been tested within a new pipeline to create a new Compara master database from scratch and the given regions of each species have been cloned correctly, regardless if they have contigs, primary assemblies (clown fish) or scaffolds (wheat) as `seqlevel`.