### PR TITLE
Added the biotype table to the list of "global" tables

### DIFF
--- a/scripts/clone_core_database.pl
+++ b/scripts/clone_core_database.pl
@@ -33,7 +33,7 @@ use POSIX;
 use Scalar::Util qw/looks_like_number/;
 
 my %global_tables = (
-  core => [qw/attrib_type meta coord_system external_db unmapped_reason/],
+  core => [qw/attrib_type meta coord_system biotype external_db unmapped_reason/],
   funcgen => [qw/ analysis analysis_description epigenome experiment experimental_group external_db feature_type meta meta_coord regulatory_build/],
 );
 


### PR DESCRIPTION
### Description

Add the `biotype` table to the test core databases.

### Use case

The script currently doesn't copy the `biotype` table, meaning that the Core API will silently return no group for all genes of the test database.

### Benefits

Biotype groups will be retrievable

### Possible Drawbacks

Slightly larger test databases (16 KB according to `SHOW TABLE STATUS`)

### Testing

_Have you added/modified unit tests to test the changes?_

No, the script doesn't have any unit tests.

_If so, do the tests pass/fail?_

_Have you run the entire test suite and no regression was detected?_

Yes
