### PR TITLE
patch_test_databases.pl: add an option for restricting the patching to specific DB types

### DIFF
--- a/scripts/patch_test_databases.pl
+++ b/scripts/patch_test_databases.pl
@@ -276,7 +276,8 @@ assume a location of
 
 Comma-separated list of database types (e.g. core, funcgen, production, ...)
 to patch. If undefined, attempt to patch databases of every type provided
-by the local MultiTestDB other than 'hive' and 'web'.
+by the local MultiTestDB other than 'hive' and 'web'. Note that the patching
+of the latter two types I<can> be requested using this option.
 
 =item B<--nofixlast>
 


### PR DESCRIPTION
### Description

Extend _patch_test_databases.pl_ so that it is possible to specify, from the command line, which database types (_e.g._ compara, core, funcgen _etc._) to patch.

### Use case

The current _ensembl-rest_ release policy stipulates that it is up to individual teams to submit PRs patching their respective test databases yet the relevant script was only able to indiscriminately patch all test-DB types present (with the exception of the hard-coded blacklist consisting of "hive" and "web", which types however are not relevant to _ensembl-rest_). This can be worked around by selective inclusion of files into Git commits but a new command-line flag controlling this has been requested.

See also: ENSCORESW-3259

### Benefits

Will make life easier for teams producing test-database patches for _ensembl-rest_, along with saving some CPU time which would otherwise be wasted on generating to-be-ignored patches.

### Possible Drawbacks

None.

### Testing

_Have you added/modified unit tests to test the changes?_

No.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

Yes, no regression detected,