### PR TITLE
Add prototype Gitlab-CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,93 @@
+stages:
+  - test
+  - posttest
+
+#
+# Test-job template
+#
+
+.ensembl_test_template:
+  image: perl:${PERL_VERSION}
+
+  services:
+    - mysql:5.6
+
+  variables:
+    # FIXME: set some password for both users
+    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    MYSQL_USER: "travis"
+    MYSQL_PASSWORD: ""
+    USER: "gitlabci"
+
+  before_script:
+    - apt-get update
+    - apt-get install -y build-essential cpanminus git
+    - apt-get install -y libmysqlclient-dev mysql-client || apt-get install -y default-libmysqlclient-dev default-mysql-client
+    - apt-get install -y libssl-dev sqlite3
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
+    # Install IO::Scalar before processing the cpanfile because one of the dependencies
+    # of Test::FTP::Server requires it yet does not declare it as a dependency, and
+    # cpanm - or to be precise the module CPAN::Meta::Prereqs - scrambles the order
+    # of entries in cpanfiles (see https://github.com/miyagawa/cpanfile/issues/42).
+    # Cpanfile upstream categorically refuses to implement the forcing of dependencies
+    # (see https://github.com/miyagawa/cpanfile/issues/3) so we will have to keep this
+    # here until either Net::FTPServer has been fixed or we stop using Test::FTP::Server
+    - cpanm -n IO::Scalar
+    - cpanm -v --installdeps --notest .
+    - ( cd ensembl && cpanm -v --installdeps --notest . )
+    - cpanm -n Devel::Cover::Report::Coveralls
+    - cpanm -n DBD::SQLite
+    - cp travisci/MultiTestDB.conf.gitlabci.mysql  modules/t/MultiTestDB.conf.mysql
+    - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
+    - mysql -u root -h mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
+
+#
+# Test jobs
+#
+
+test:perl5.14-sqlite:
+  stage: test
+  extends: .ensembl_test_template
+  variables:
+    PERL_VERSION: "5.14"
+    COVERALLS: "false"
+    DB: "sqlite"
+  script:
+    - ./travisci/harness.sh
+
+test:perl5.30-mysql:
+  stage: test
+  extends: .ensembl_test_template
+  variables:
+    PERL_VERSION: "5.30"
+    # Note: relies on the secret variable COVERALLS_REPO_TOKEN for report uploads to work
+    COVERALLS: "true"
+    DB: "mysql"
+  script:
+    - ./travisci/harness.sh
+
+#
+# Triggers for dependent builds
+#
+
+# The template. It doesn't presently support PRs before they are
+# merged (would need extended run condition and better selection of
+# downstream branches) - but then again, we do not trigger dependent
+# builds for PRs on Travis either.
+.dependent_template:
+  stage: posttest
+  # We want this to run even if any test jobs fail
+  when: always
+  only:
+    - master
+    - /^release/\d+$/
+  trigger:
+    # Use the same branch as in this project
+    branch: ${CI_COMMIT_REF_NAME}
+
+# Actual trigger jobs
+post:trigger_main:
+  extends: .dependent_template
+  trigger:
+    project: ensembl-gh-mirror/ensembl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
 #
 
 .ensembl_test_template:
-  image: perl:${PERL_VERSION}
+  image: dockerhub.ebi.ac.uk/ensembl-infrastructure/ensembl-ci-docker-images:${PERL_VERSION}
 
   services:
     - mysql:5.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,3 @@
-stages:
-  - test
-  - posttest
-
 #
 # Test-job template
 #
@@ -76,9 +72,7 @@ test:perl5.30-mysql:
 # downstream branches) - but then again, we do not trigger dependent
 # builds for PRs on Travis either.
 .dependent_template:
-  stage: posttest
-  # We want this to run even if any test jobs fail
-  when: always
+  stage: test
   only:
     - master
     - /^release/\d+$/
@@ -87,7 +81,7 @@ test:perl5.30-mysql:
     branch: ${CI_COMMIT_REF_NAME}
 
 # Actual trigger jobs
-post:trigger_main:
+test:trigger_main:
   extends: .dependent_template
   trigger:
     project: ensembl-gh-mirror/ensembl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@
   before_script:
     - apt-get update
     - apt-get install -y build-essential cpanminus git
-    - apt-get install -y libmysqlclient-dev mysql-client || apt-get install -y default-libmysqlclient-dev default-mysql-client
+    - apt-get install -y default-libmysqlclient-dev default-mysql-client
     - apt-get install -y libssl-dev sqlite3
     - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl.git
     - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git

--- a/travisci/MultiTestDB.conf.gitlabci.mysql
+++ b/travisci/MultiTestDB.conf.gitlabci.mysql
@@ -1,0 +1,6 @@
+{
+  'driver' => 'mysql',
+  'host'   => 'mysql',
+  'port'   => '3306',
+  'user'   => 'travis',
+}


### PR DESCRIPTION
### Description

Add the files necessary for _ensembl-test_ CI to run on EBI GitLab, including triggering dependent builds on the GitLab mirror of _ensembl_. Confirmed to work.

### Use case

Core repositories are to be migrated from Travis to EBI Gitlab-CI.

### Benefits

Will make it easier to test further work on Core Gitlab-CI set-up. Better integration of multi-project pipelines than what we have on Travis because we are limited to the free tier on the latter.

### Possible Drawbacks

For the time being we will have CI jobs running on both systems.

## Testing

_Have you added/modified unit tests to test the changes?_

No, this is a change on the level of the CI environment which runs unit tests rather than in the code checked by those tests.

_If so, do the tests pass/fail?_

N/A

_Have you run the entire test suite and no regression was detected?_

N/A
