### PR TITLE
Mysql 8 comressed data import

### DIFF
--- a/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm
+++ b/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm
@@ -42,9 +42,21 @@ use base 'Bio::EnsEMBL::Test::MultiTestDB';
 
 sub load_txt_dump {
     my ($self, $txt_file, $tablename, $db) = @_;
-    my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s` FIELDS ESCAPED BY '\\\\'}, $txt_file, $tablename);
-    $db->do($load);
-    return $db;
+    if(index($txt_file, 'compressed_genotype_var') != -1) {
+    	my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' 
+    	 SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);	
+    	$db->do($load);
+    	return $db;
+    } elsif (index($txt_file, 'compressed_genotype_region') != -1) {
+    	my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' (sample_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, @var1) SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);	
+    	$db->do($load);
+    	return $db;
+    } else {
+    	my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s` FIELDS ESCAPED BY '\\\\'}, $txt_file, $tablename);
+    	$db->do($load);
+    	return $db;
+    }
+    
 }
 
 sub create_and_use_db {


### PR DESCRIPTION
### Description

Mysql 8 build failed because commpressed data couldnt be imported as binary any more. 
We intoduce this changes to import compressed genome in HEX format

### Use case

Ensembl for Ubuntu20 - mysql 8+
### Benefits

We can use ensembl on new system (ubuntu 20)

### Possible Drawbacks

Now field for this compressed tables are hardcoded, there is no other way to importbinary fields tho

### Testing

All tests passed
