### PR TITLE
Fix db load

### DIFF
--- a/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm
+++ b/modules/Bio/EnsEMBL/Test/MultiTestDB/mysql.pm
@@ -43,12 +43,11 @@ use base 'Bio::EnsEMBL::Test::MultiTestDB';
 sub load_txt_dump {
     my ($self, $txt_file, $tablename, $db) = @_;
     if(index($txt_file, 'compressed_genotype_var') != -1) {
-    	my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' 
-    	 SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);	
+      my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' (variation_id, subsnp_id , @var1) SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);
     	$db->do($load);
     	return $db;
     } elsif (index($txt_file, 'compressed_genotype_region') != -1) {
-    	my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' (sample_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, @var1) SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);	
+      my $load = sprintf(q{LOAD DATA LOCAL INFILE '%s' INTO TABLE `%s`FIELDS ESCAPED BY '\\\\' (sample_id, seq_region_id, seq_region_start, seq_region_end, seq_region_strand, @var1) SET genotypes = UNHEX(@var1)}, $txt_file, $tablename);
     	$db->do($load);
     	return $db;
     } else {
@@ -56,7 +55,7 @@ sub load_txt_dump {
     	$db->do($load);
     	return $db;
     }
-    
+
 }
 
 sub create_and_use_db {


### PR DESCRIPTION
The same pr https://github.com/Ensembl/ensembl-test/pull/57 against 104 branch

### Description

One of the compressed table were not loading correctly, this is the bug fix

### Use case
When we load from ensembl-rest compressed_genotype_var it is not loaded correctly

### Benefits

this is bugfix

### Possible Drawbacks

not applicaple

### Testing

no tests needed in this repo

_If so, do the tests pass/fail?_

It's needed to verify that tests in ensembl pass fine. here is the link for the test ensembl branch 
https://github.com/Ensembl/ensembl/commit/112d59d38ea080959df7c8c763b00d24eb8ef10d
