### PR TITLE
added master-main fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@
     - apt-get install -y build-essential cpanminus git
     - apt-get install -y default-libmysqlclient-dev default-mysql-client
     - apt-get install -y libssl-dev sqlite3
-    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch=main --depth=1 https://github.com/Ensembl/ensembl.git
     - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
     # Install IO::Scalar before processing the cpanfile because one of the dependencies
     # of Test::FTP::Server requires it yet does not declare it as a dependency, and

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
     - unzip
 
 before_install:
-  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
+  - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl.git
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:


### PR DESCRIPTION
### Description

Fixed git clone command for GitLab

### Use case

GitLab CI/CD pipeline was failing because "master" branch does not exist anymore for "Ensembl/ensembl" repo.

### Benefits

Fix GitLab CI/CD pipeline

### Possible Drawbacks

None

### Testing

N/A

