### PR TITLE
Restrain using DBD::mysql version 5.x on main

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'Test::More';
 requires 'Test::Warnings';
 requires 'Devel::Peek';


### PR DESCRIPTION
## Description

Related to [Ensembl PR #666 ](https://github.com/Ensembl/ensembl/pull/666)

## Use case

Keep support for MySQL 5x

## Benefits

Keep support for MySQL 5x

## Possible Drawbacks

Using outdated DBD::mysql

## Testing

Automated tests ran fine
