### PR TITLE
Restrain using latest DBD::mysql version for Release 110

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,5 @@
 requires 'DBI';
-requires 'DBD::mysql';
+requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
 requires 'Test::More';
 requires 'Test::Warnings';
 requires 'Devel::Peek';


### PR DESCRIPTION
Due to updates to `release/110` branch, we need to update the cpanfile to restrict the version of DBD::mysql to keep support for version 5. 

Related to PR: https://github.com/Ensembl/ensembl/pull/666