### PR TITLE
Mini-extension to handle 'fetch_all_by_stable_id_list' method

### DIFF
--- a/scripts/clone_core_database.pl
+++ b/scripts/clone_core_database.pl
@@ -300,8 +300,14 @@ sub copy_features {
   my $to_adaptor = $to->get_adaptor($name);
   my $method = $adaptor_info->{method} || 'fetch_all_by_Slice';
   my $args = $adaptor_info->{args} || [];
+
   foreach my $slice (@{$slices}) {
-    my $features = $from_adaptor->$method($slice, @{$args});
+    my $features;
+    if ($method eq 'fetch_all_by_Slice') {
+      $features = $from_adaptor->$method($slice, @{$args});
+    } else {
+      $features = $from_adaptor->$method($args);
+    }
     my $total_features = scalar(@{$features});
     my $count = 0;
     foreach my $f (@{$features}) {


### PR DESCRIPTION
### Description

Mini-extension to handle 'fetch_all_by_stable_id_list' method.
The script did not work initially because it was using the $slice as first method parameter.

### Use case

'fetch_all_by_stable_id_list' works ... for gene features at least.

### Benefits

Ability to select/dump a subset of genes 

### Possible Drawbacks

None

### Testing

Used manually. Scripts are not usually covered by test [sic!]

