### PR TITLE
[114] Update travis badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ensembl test harness and related utility scripts
 
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-test.svg?branch=master)][travis]
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-test.svg?branch=release/114)][travis]
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-test


### PR DESCRIPTION
Update travis badge for new `release/114` branch.

Apologies, I forgot to update the travis branch in the README before pushing the new release branch.