### PR TITLE
Tidying up TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,22 @@
-dist: xenial
+dist: focal
 
 language: perl
 
 perl:
   - '5.26'
-  - '5.30'
+  - '5.32'
 
 services:
   - mysql
 
 env:
   matrix:
-  - COVERALLS=true  DB=mysql
-  - COVERALLS=false DB=mysql
-  - COVERALLS=false DB=sqlite
+  - DB=mysql
+  - DB=sqlite
   global:
     secure: EbGoRzfTTy/nlGPRYOEhKcYnIIrUHeM5etlqdAsMrfOkCCVJe7/QIWUG7hx1qdprIPdrKZ0jnmzBO3STz5m+TrsE/rAZjTM/MyEtwxAFEsdNlOKeozyE4Y4kwFMOqiLAFhHPtd3JhV92VMj3VSGVLkhNaaXbz1kj/aU14hOhbT4=
 
 sudo: false
-
-addons:
-  apt:
-    packages:
-    - unzip
 
 before_install:
   - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl.git
@@ -36,27 +30,19 @@ install:
   # Cpanfile upstream categorically refuses to implement the forcing of dependencies
   # (see https://github.com/miyagawa/cpanfile/issues/3) so we will have to keep this
   # here until either Net::FTPServer has been fixed or we stop using Test::FTP::Server
-  - cpanm -n IO::Scalar
+  - cpanm -n Net::FTPServer Test::FTP::Server
   - cpanm -v --installdeps --notest .
-  - cpanm -n Devel::Cover::Report::Coveralls
-  - cpanm -n DBD::SQLite
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'
+  - mysql -u root -h localhost -e 'SET GLOBAL local_infile=1'
 
 script: "./travisci/harness.sh"
 
-jobs:
-  include:
-  - stage: trigger_dependent_builds
-    script: "./travisci/trigger-dependent-build.sh"
-
 matrix:
   exclude:
-  - perl: '5.30'
-    env: COVERALLS=true DB=mysql
   - perl: '5.26'
-    env: COVERALLS=false  DB=mysql
+    env: DB=sqlite
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
   global:
     secure: EbGoRzfTTy/nlGPRYOEhKcYnIIrUHeM5etlqdAsMrfOkCCVJe7/QIWUG7hx1qdprIPdrKZ0jnmzBO3STz5m+TrsE/rAZjTM/MyEtwxAFEsdNlOKeozyE4Y4kwFMOqiLAFhHPtd3JhV92VMj3VSGVLkhNaaXbz1kj/aU14hOhbT4=
 
-sudo: false
-
 before_install:
   - git clone --branch main --depth 1 https://github.com/Ensembl/ensembl.git
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
@@ -30,8 +28,8 @@ install:
   # Cpanfile upstream categorically refuses to implement the forcing of dependencies
   # (see https://github.com/miyagawa/cpanfile/issues/3) so we will have to keep this
   # here until either Net::FTPServer has been fixed or we stop using Test::FTP::Server
-  - cpanm -n Net::FTPServer Test::FTP::Server
-  - cpanm -v --installdeps --notest .
+  - cpanm -v --notest --sudo Net::FTPServer Test::FTP::Server
+  - cpanm -v --sudo --installdeps --notest .
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql
   - cp travisci/MultiTestDB.conf.travisci.SQLite modules/t/MultiTestDB.conf.SQLite
   - mysql -u root -h localhost -e 'GRANT ALL PRIVILEGES ON *.* TO "travis"@"%"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   # Cpanfile upstream categorically refuses to implement the forcing of dependencies
   # (see https://github.com/miyagawa/cpanfile/issues/3) so we will have to keep this
   # here until either Net::FTPServer has been fixed or we stop using Test::FTP::Server
+  - cpanm --notest --sudo Archive::Zip Authen::PAM BSD::Resource File::Sync IO::Scalar
   - cpanm -v --notest --sudo Net::FTPServer Test::FTP::Server
   - cpanm -v --sudo --installdeps --notest .
   - cp travisci/MultiTestDB.conf.travisci.mysql  modules/t/MultiTestDB.conf.mysql

--- a/cpanfile
+++ b/cpanfile
@@ -1,9 +1,12 @@
 requires 'DBI';
-requires 'DBD::mysql', '<= 4.050'; # newer versions do not support MySQL 5
+requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
+requires 'DBD::SQLite';
 requires 'Test::More';
 requires 'Test::Warnings';
-requires 'Devel::Peek';
+requires 'Devel::Cover';
+requires 'Devel::Cover::Report::Coveralls';
 requires 'Devel::Cycle';
+requires 'Devel::Peek';
 requires 'Error';
 requires 'PadWalker';
 requires 'Test::Builder::Module';

--- a/cpanfile
+++ b/cpanfile
@@ -3,8 +3,6 @@ requires 'DBD::mysql', '< 5.0'; # newer versions do not support MySQL 5
 requires 'DBD::SQLite';
 requires 'Test::More';
 requires 'Test::Warnings';
-requires 'Devel::Cover';
-requires 'Devel::Cover::Report::Coveralls';
 requires 'Devel::Cycle';
 requires 'Devel::Peek';
 requires 'Error';

--- a/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
+++ b/modules/t/test-genome-DBs/multi/compara/SQLite/table.sql
@@ -351,7 +351,8 @@ CREATE TABLE "genomic_align_block" (
   "perc_id" tinyint,
   "length" integer NOT NULL,
   "group_id" bigint,
-  "level_id" tinyint NOT NULL DEFAULT 0
+  "level_id" tinyint NOT NULL DEFAULT 0,
+  "direction" tinyint DEFAULT NULL
 );
 
 --


### PR DESCRIPTION
## Description

- Moved Perl deps from `.travis.yml` to `cpanfile` 
- Exception: `Net::FTPServer` `Test::FTP::Server` fail tests - known bug with Debian-based distros
- removed `dependent build` from `.travis.yml`
- fixed max supported Perl version by Travis `focal` ([build environment](https://docs.travis-ci.com/user/reference/focal/#perl-support))
- harmonised max tested Perl version to `5.32`
- removed COVERALLS
- fixed SQLite support

## Use case

Minor optimisations, and SQLite bug fix (test db schema)

## Benefits

Better tracking and handling of Perl dependencies

## Possible Drawbacks

None

## Testing

No tests were updated or added.
Test suite could run successfully
